### PR TITLE
oto.ini 関連の変数名を変更

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -62,96 +62,96 @@ def ust2otoini_mono(ustobj, name_wav, path_tablefile, dt=100):
         length = note.get_length_ms(tempo)
         simple_oto = otoini.Oto()
         simple_oto.filename = name_wav
-        simple_oto.alies = note.lyric
-        simple_oto.lblank = t
+        simple_oto.alias = note.lyric
+        simple_oto.offset = t
         simple_oto.overlap = 0
-        simple_oto.onset = 0
-        simple_oto.fixed = length
-        simple_oto.rblank = -length  # 負で左ブランク相対時刻, 正で絶対時刻
+        simple_oto.preutterance = 0
+        simple_oto.consonant = length
+        simple_oto.cutoff = -length  # 負で左ブランク相対時刻, 正で絶対時刻
         l.append(simple_oto)
         t += length  # 今のノート終了位置が次のノート開始位置
     # 音素単位に分割
     new = []  # mono_otoを入れるリスト
     for simple_oto in l:
         try:
-            phonemes = d[simple_oto.alies]
+            phonemes = d[simple_oto.alias]
         except KeyError as e:
             print('\nKeyError in utaupy.convert.ust2otoini_mono---------')
             print('ひらがなローマ字変換に失敗しました。半角スペースで音素として分割してぶち込みます。')
-            print('エラー詳細:')
+            print('エラー詳細:', e)
             print('--------------------------------------\n')
-            phonemes = simple_oto.alies.split()
+            phonemes = simple_oto.alias.split()
             print(phonemes)
         # 子音+母音 「か(k a)」
         if len(phonemes) == 2:
             # 子音部分
             first_oto = otoini.Oto()
             first_oto.filename = name_wav
-            first_oto.alies = phonemes[0]
-            first_oto.lblank = simple_oto.lblank - (2 * dt)
+            first_oto.alias = phonemes[0]
+            first_oto.offset = simple_oto.offset - (2 * dt)
             first_oto.overlap = 0
-            first_oto.onset = dt
-            first_oto.fixed = 2 * dt
-            first_oto.rblank = - 2 * dt
+            first_oto.preutterance = dt
+            first_oto.consonant = 2 * dt
+            first_oto.cutoff = - 2 * dt
             new.append(first_oto)
             # 母音部分
             second_oto = otoini.Oto()
             second_oto.filename = name_wav
-            second_oto.alies = phonemes[1]
-            second_oto.lblank = simple_oto.lblank - dt
+            second_oto.alias = phonemes[1]
+            second_oto.offset = simple_oto.offset - dt
             second_oto.overlap = 0
-            second_oto.onset = dt
-            second_oto.fixed = 2 * dt
-            second_oto.rblank = simple_oto.rblank - dt
+            second_oto.preutterance = dt
+            second_oto.consonant = 2 * dt
+            second_oto.cutoff = simple_oto.cutoff - dt
             new.append(second_oto)
         # 母音など 「あ(a)」「ん(cl)」「っ(cl)」「(pau)」「(br)」「(sil)」
         elif len(phonemes) == 1:
             first_oto = otoini.Oto()
             first_oto.filename = name_wav
-            first_oto.alies = phonemes[0]
-            first_oto.lblank = simple_oto.lblank - dt
+            first_oto.alias = phonemes[0]
+            first_oto.offset = simple_oto.offset - dt
             first_oto.overlap = 0
-            first_oto.onset = dt
-            first_oto.fixed = 2 * dt
-            first_oto.rblank = simple_oto.rblank - dt
+            first_oto.preutterance = dt
+            first_oto.consonant = 2 * dt
+            first_oto.cutoff = simple_oto.cutoff - dt
             new.append(first_oto)
         # 子音+半母音+母音 「ぐぁ(g w a)」
         elif len(phonemes) == 3:
             # 子音部分
             first_oto = otoini.Oto()
             first_oto.filename = name_wav
-            first_oto.alies = phonemes[0]
-            first_oto.lblank = simple_oto.lblank - (2 * dt)
+            first_oto.alias = phonemes[0]
+            first_oto.offset = simple_oto.offset - (2 * dt)
             first_oto.overlap = 0
-            first_oto.onset = dt
-            first_oto.fixed = 2 * dt
-            first_oto.rblank = - 2 * dt
+            first_oto.preutterance = dt
+            first_oto.consonant = 2 * dt
+            first_oto.cutoff = - 2 * dt
             new.append(first_oto)
             # 半母音部分
             second_oto = otoini.Oto()
             second_oto.filename = name_wav
-            second_oto.alies = phonemes[1]
-            second_oto.lblank = simple_oto.lblank - dt
+            second_oto.alias = phonemes[1]
+            second_oto.offset = simple_oto.offset - dt
             second_oto.overlap = 0
-            second_oto.onset = dt
-            second_oto.fixed = 2 * dt
-            second_oto.rblank = - 2 * dt
+            second_oto.preutterance = dt
+            second_oto.consonant = 2 * dt
+            second_oto.cutoff = - 2 * dt
             new.append(second_oto)
             # 母音部分
             third_oto = otoini.Oto()
             third_oto.filename = name_wav
-            third_oto.alies = phonemes[2]
-            third_oto.lblank = simple_oto.lblank
+            third_oto.alias = phonemes[2]
+            third_oto.offset = simple_oto.offset
             third_oto.overlap = 0
-            third_oto.onset = dt
-            third_oto.fixed = 2 * dt
-            third_oto.rblank = simple_oto.rblank - (2 * dt)
+            third_oto.preutterance = dt
+            third_oto.consonant = 2 * dt
+            third_oto.cutoff = simple_oto.cutoff - (2 * dt)
             new.append(third_oto)
         else:
-            raise ValueError('len(alies) must be in [1, 2, 3]')
+            raise ValueError('len(alias) must be in [1, 2, 3]')
 
-    new[0].lblank = 0
-    new[0].onset = 0
+    new[0].offset = 0
+    new[0].preutterance = 0
     mono_otoini = otoini.OtoIni()
     mono_otoini.values = new
     return mono_otoini
@@ -175,7 +175,7 @@ def ust2otoini_romaji_cv(ustobj, name_wav, path_tablefile, dt=100, debug=False):
 
     for note in notes[2:-1]:
         if debug:
-            print('    '.format(note.values))
+            print(f'    {note.values}')
         try:
             phonemes = d[note.lyric]
         except KeyError as e:
@@ -188,28 +188,28 @@ def ust2otoini_romaji_cv(ustobj, name_wav, path_tablefile, dt=100, debug=False):
         length = note.get_length_ms(tempo)
         oto = otoini.Oto()
         oto.filename = name_wav
-        oto.alies = ' '.join(phonemes)
-        oto.lblank = t - (2 * dt)
-        oto.fixed = min(3 * dt, length + 2 * dt)
-        oto.rblank = -(length + 2 * dt)  # 負で左ブランク相対時刻, 正で絶対時刻
+        oto.alias = ' '.join(phonemes)
+        oto.offset = t - (2 * dt)
+        oto.consonant = min(3 * dt, length + 2 * dt)
+        oto.cutoff = -(length + 2 * dt)  # 負で左ブランク相対時刻, 正で絶対時刻
         if len(phonemes) == 1:
             oto.overlap = 2 * dt
-            oto.onset = 3 * dt
+            oto.preutterance = 3 * dt
         elif len(phonemes) in [2, 3]:
             oto.overlap = dt
-            oto.onset = 2 * dt
+            oto.preutterance = 2 * dt
         else:
-            print('\nERROR when setting alies : phonemes = {}-------------'.format(phonemes))
-            raise ValueError('1エイリアスあたり 1, 2, 3 音素しか対応していません。')
-            oto.alies = ''.join(phonemes)
+            print('\nERROR when setting alias : phonemes = {}-------------'.format(phonemes))
+            print('1エイリアスあたり 1, 2, 3 音素しか対応していません。')
+            oto.alias = ''.join(phonemes)
             oto.overlap = dt
-            oto.onset = 2 * dt
+            oto.preutterance = 2 * dt
 
         l.append(oto)
         t += length  # 今のノート終了位置が次のノート開始位置
 
-    l[0].lblank = 0  # 最初の左ブランクを0にする
-    l[0].onset = 0
+    l[0].offset = 0  # 最初の左ブランクを0にする
+    l[0].preutterance = 0
     l[0].overlap = 0  # 最初のオーバーラップを0にする
     otoiniobj = otoini.OtoIni()
     otoiniobj.values = l
@@ -245,8 +245,8 @@ def otoini2label(otoiniobj, mode='auto',
         for oto in otoini_values:
             if debug:
                 print('    {}'.format(oto.values))
-            t_start = (oto.lblank + oto.onset) * time_order_ratio
-            tmp.append([int(t_start), oto.alies])
+            t_start = (oto.offset + oto.preutterance) * time_order_ratio
+            tmp.append([int(t_start), oto.alias])
             # [[発音開始時刻, 発音終了時刻, 発音記号], ...]
         lines = [[v[0], tmp[i + 1][0], v[1]] for i, v in enumerate(tmp[:-1])]
         # ↓内包表記を展開した場合↓-----
@@ -260,11 +260,11 @@ def otoini2label(otoiniobj, mode='auto',
             print('    {}'.format(oto.values))
 
         # 発声開始位置
-        t_start = int((oto.lblank + oto.onset) * time_order_ratio)
+        t_start = int((oto.offset + oto.preutterance) * time_order_ratio)
         # 発声終了位置(右ブランクの符号ごとの挙動違いに対応)
-        t_end = int(oto.rblank2 * time_order_ratio)
+        t_end = int(oto.cutoff2 * time_order_ratio)
         # 最終ノートをリストに追加
-        lines.append([t_start, t_end, oto.alies])
+        lines.append([t_start, t_end, oto.alias])
 
     elif mode == 'romaji_cv':
         print('  mode: OtoIni(romaji_cv) -> Label(mono)')
@@ -277,8 +277,8 @@ def otoini2label(otoiniobj, mode='auto',
             if debug:
                 print('    {}'.format(oto.values))
 
-            t_start = (oto.lblank + oto.overlap) * time_order_ratio
-            tmp.append([int(t_start), oto.alies])
+            t_start = (oto.offset + oto.overlap) * time_order_ratio
+            tmp.append([int(t_start), oto.alias])
 
         # [[発音開始時刻, 発音終了時刻, 発音記号], ...]
         lines = [[v[0], tmp[i + 1][0], v[1]] for i, v in enumerate(tmp[:-1])]
@@ -293,11 +293,11 @@ def otoini2label(otoiniobj, mode='auto',
         if debug:
             print('    {}'.format(oto.values))
         # 発声開始位置
-        t_start = int((oto.lblank + oto.overlap) * time_order_ratio)
+        t_start = int((oto.offset + oto.overlap) * time_order_ratio)
         # 発声終了位置(右ブランクの符号ごとの挙動違いに対応)
-        t_end = int(oto.rblank2 * time_order_ratio)
+        t_end = int(oto.cutoff2 * time_order_ratio)
         # 最終ノートをリストに追加
-        lines.append([t_start, t_end, oto.alies])
+        lines.append([t_start, t_end, oto.alias])
 
     else:
         raise ValueError('argument \'mode\' must be in {}'.format(allowed_modes))
@@ -325,12 +325,12 @@ def label2otoini(labelobj, name_wav,
         t = line[1] - line[0]
         oto = otoini.Oto()
         oto.filename = name_wav
-        oto.alies = line[2]
-        oto.lblank = line[0]
+        oto.alias = line[2]
+        oto.offset = line[0]
         oto.overlap = 0.0
-        oto.onset = 0.0
-        oto.fixed = t
-        oto.rblank = -t
+        oto.preutterance = 0.0
+        oto.consonant = t
+        oto.cutoff = -t
         l.append(oto)
     # クラスオブジェクト化
     o = otoini.OtoIni()

--- a/convert.py
+++ b/convert.py
@@ -38,10 +38,11 @@ def make_finalnote_R(ust):
     """Ustの最後のノートが必ず休符 になるようにする"""
     notes = ust.values
     # Ust内の最後はTRACKENDなので後ろから二番目のノートで判定
+    # DEBUG: NoteのIDが引き継がれるっぽくて最後から2番目のノートもRになってしまう。
     if notes[-2].lyric not in ('pau', 'sil', 'R'):
-        print(notes[-2].values)
+        print('****', notes[-2].values, '****')
         extra_note = _ust.Note()
-        extra_note.values = notes[-2]
+        extra_note.values = notes[-2].values
         extra_note.lyric = 'R'
         notes.insert(-1, extra_note)
     processed_ust = _ust.Ust()

--- a/convert.py
+++ b/convert.py
@@ -5,6 +5,7 @@ UTAU関連ファイルの相互変換
 """
 # from pysnooper import snoop
 # from pprint import pprint
+from copy import deepcopy
 
 from . import label as _label
 from . import otoini as _otoini
@@ -37,12 +38,12 @@ def ust2otoini(ust, name_wav, path_tablefile, mode='romaji_cv', dt=100, debug=Fa
 def make_finalnote_R(ust):
     """Ustの最後のノートが必ず休符 になるようにする"""
     notes = ust.values
-    # Ust内の最後はTRACKENDなので後ろから二番目のノートで判定
+    note = notes[-2]
+    # Ust内の最後はTRACKENDなので後ろから2番目のノートで判定
     # DEBUG: NoteのIDが引き継がれるっぽくて最後から2番目のノートもRになってしまう。
-    if notes[-2].lyric not in ('pau', 'sil', 'R'):
-        print('****', notes[-2].values, '****')
-        extra_note = _ust.Note()
-        extra_note.values = notes[-2].values
+    if note.lyric not in ('pau', 'sil', 'R'):
+        print('  末尾に休符を自動追加しました。')
+        extra_note = deepcopy(note)
         extra_note.lyric = 'R'
         notes.insert(-1, extra_note)
     processed_ust = _ust.Ust()

--- a/otoini.py
+++ b/otoini.py
@@ -5,7 +5,7 @@ setParam用のINIファイルとデータを扱うモジュールです。
 """
 import re
 
-from . import table
+# from . import table
 
 
 def main():
@@ -51,10 +51,10 @@ class OtoIni:
         """中身を上書きする"""
         self.__values = list_of_oto
 
-    def replace_alieses(self, before, after):
+    def replace_aliases(self, before, after):
         """エイリアスを置換する"""
         for oto in self.__values:
-            oto.alies = oto.alies.replace(before, after)
+            oto.alias = oto.alias.replace(before, after)
         return self
 
     def is_mono(self):
@@ -62,7 +62,7 @@ class OtoIni:
         モノフォン形式のエイリアスになっているか判定する。
         返り値はbool。
         """
-        return all(len(v.alies.split()) == 1 for v in self.values)
+        return all(len(v.alias.split()) == 1 for v in self.values)
 
     # def kana2romaji(self, path_table, replace=True, dt=100):
     #     """
@@ -78,7 +78,7 @@ class OtoIni:
     #               '息': ['br'], '吸': ['br'], 'br': ['br']})
     #     # 発音記号の分割数によってパラメータを調整
     #     for oto in self.__values:
-    #         kana = oto.alies.split()[-1]
+    #         kana = oto.alias.split()[-1]
     #         try:
     #             romaji = d[kana]
     #         # KeyErrorはリストにするだけで返される
@@ -91,24 +91,24 @@ class OtoIni:
     #             romaji = d[kana]
     #         # 歌詞をローマ字化
     #         if replace is True:
-    #             oto.alies = ' '.join(romaji)
+    #             oto.alias = ' '.join(romaji)
     #         # モノフォン
     #         if len(romaji) == 1:
-    #             # print('  alies: {}\t-> {}\t: オーバーラップ右シフト・先行発声右詰め'.format(alies, romaji))
+    #             # print('  alias: {}\t-> {}\t: オーバーラップ右シフト・先行発声右詰め'.format(alias, romaji))
     #             oto.overlap = 2 * dt
-    #             oto.onset = oto.fixed
+    #             oto.preutterance = oto.consonant
     #         # おもにCV形式のとき
     #         elif len(romaji) == 2:
-    #             # print('  alies: {}\t-> {}\t: そのまま'.format(alies, romaji))
+    #             # print('  alias: {}\t-> {}\t: そのまま'.format(alias, romaji))
     #             pass
     #         # おもにCCV形式のとき
     #         elif len(romaji) == 3:
-    #             # print('  alies: {}\t-> {}\t: そのままでいい？'.format(alies, romaji))
+    #             # print('  alias: {}\t-> {}\t: そのままでいい？'.format(alias, romaji))
     #             pass
     #         elif len(romaji) >= 4:
     #             print('  [ERROR]---------')
     #             print('  1,2,3音素しか対応していません。')
-    #             print('  alies: {}\t-> {}\t: そのままにします。'.format(kana, romaji))
+    #             print('  alias: {}\t-> {}\t: そのままにします。'.format(kana, romaji))
     #             print('  ----------------')
 
     def monophonize(self):
@@ -116,43 +116,43 @@ class OtoIni:
         # 新規OtoIniを作るために、otoを入れるリスト
         l = []
         for oto in self.__values:
-            alieses = oto.alies.split()
-            if len(alieses) == 1:
+            aliases = oto.alias.split()
+            if len(aliases) == 1:
                 l.append(oto)
-            elif len(alieses) in [2, 3]:
+            elif len(aliases) in [2, 3]:
                 name_wav = oto.filename
                 # 1文字目(オーバーラップから先行発声まで)------------
                 tmp = Oto()
-                a = alieses[0]
-                t = oto.lblank + oto.overlap  # オーバーラップの位置から
+                a = aliases[0]
+                t = oto.offset + oto.overlap  # オーバーラップの位置から
                 tmp.filename = name_wav
-                tmp.alies = a
-                tmp.lblank = t
+                tmp.alias = a
+                tmp.offset = t
                 tmp.overlap = 0
                 l.append(tmp)
                 # 2文字目(先行発声から固定範囲まで)----------------
                 tmp = Oto()
-                a = alieses[1]
-                t = oto.lblank + oto.onset  # 先行発声の位置から
+                a = aliases[1]
+                t = oto.offset + oto.preutterance  # 先行発声の位置から
                 tmp.filename = name_wav
-                tmp.alies = a
-                tmp.lblank = t
+                tmp.alias = a
+                tmp.offset = t
                 tmp.overlap = 0
                 l.append(tmp)
-                if len(alieses) == 3:
+                if len(aliases) == 3:
                     # 3文字目(固定範囲から右ブランクまで)----------------
                     tmp = Oto()
-                    a = alieses[2]
-                    t = oto.lblank + oto.fixed  # 固定範囲の位置から
+                    a = aliases[2]
+                    t = oto.offset + oto.consonant  # 固定範囲の位置から
                     tmp.filename = name_wav
-                    tmp.alies = a
-                    tmp.lblank = t
+                    tmp.alias = a
+                    tmp.offset = t
                     tmp.overlap = 0
                     l.append(tmp)
             else:
                 print('\n[ERROR in otoini.monophonize()]----------------')
                 print('エイリアスのローマ字分割数は 1, 2, 3 以外対応していません。')
-                print('alieses: {}'.format(alieses))
+                print('aliases: {}'.format(aliases))
                 print('文字を連結して処理を続行します。')
                 print('-----------------------------------------------\n')
                 l.append(oto)
@@ -164,11 +164,11 @@ class OtoIni:
         for oto in self.__values:
             l = []
             l.append(oto.filename)
-            l.append(oto.alies)
-            l.append(oto.lblank)
-            l.append(oto.fixed)
+            l.append(oto.alias)
+            l.append(oto.offset)
+            l.append(oto.consonant)
             l.append(oto.rblank)
-            l.append(oto.onset)
+            l.append(oto.preutterance)
             l.append(oto.overlap)
             # 数値部分を丸めてから文字列に変換
             l = l[:2] + [str(round(float(v), 4)) for v in l[2:]]
@@ -182,15 +182,15 @@ class Oto:
     """oto.ini中の1モーラ"""
 
     def __init__(self):
-        keys = ('FileName', 'Alies', 'LBlank',
-                'Fixed', 'RBlank', 'Onset', 'Overlap')
+        keys = ('FileName', 'Alias', 'Offset',
+                'Consonant', 'RBlank', 'Preutterance', 'Overlap')
         l = [None] * 7
         self.__d = dict(zip(keys, l))
 
     def from_otoini(self, l):
         """1音分のリストをもらってクラスオブジェクトにする"""
-        keys = ('FileName', 'Alies', 'LBlank',
-                'Fixed', 'RBlank', 'Onset', 'Overlap')
+        keys = ('FileName', 'Alias', 'Offset',
+                'Consonant', 'RBlank', 'Preutterance', 'Overlap')
         # 数値部分をfloatにする
         l = l[:2] + [float(v) for v in l[2:]]
         self.__d = dict(zip(keys, l))
@@ -220,34 +220,34 @@ class Oto:
         self.__d['FileName'] = x
 
     @property
-    def alies(self):
+    def alias(self):
         """エイリアスを確認する"""
-        return self.__d['Alies']
+        return self.__d['Alias']
 
-    @alies.setter
-    def alies(self, x):
+    @alias.setter
+    def alias(self, x):
         """エイリアスを上書きする"""
-        self.__d['Alies'] = x
+        self.__d['Alias'] = x
 
     @property
-    def lblank(self):
+    def offset(self):
         """左ブランクを確認する"""
-        return self.__d['LBlank']
+        return self.__d['Offset']
 
-    @lblank.setter
-    def lblank(self, x):
+    @offset.setter
+    def offset(self, x):
         """左ブランクを上書きする"""
-        self.__d['LBlank'] = x
+        self.__d['Offset'] = x
 
     @property
-    def fixed(self):
+    def consonant(self):
         """固定範囲を確認する"""
-        return self.__d['Fixed']
+        return self.__d['Consonant']
 
-    @fixed.setter
-    def fixed(self, x):
+    @consonant.setter
+    def consonant(self, x):
         """固定範囲を上書きする"""
-        self.__d['Fixed'] = x
+        self.__d['Consonant'] = x
 
     @property
     def rblank(self):
@@ -262,23 +262,23 @@ class Oto:
     @property
     def rblank2(self):
         """右ブランクを絶対時刻で取得する"""
-        return max(self.__d['RBlank'], self.__d['LBlank'] - self.__d['RBlank'])
+        return max(self.__d['RBlank'], self.__d['Offset'] - self.__d['RBlank'])
 
-    # LBlankがNullのとき処理できず、バグのもとになるので無効化
+    # OffsetがNullのとき処理できず、バグのもとになるので無効化
     # @rblank2.setter
     # def rblank2(self, x):
     #     """右ブランクを上書きする。負の値に強制する。"""
-    #     self.__d['RBlank'] = min(x, self.__d['LBlank'] - x)
+    #     self.__d['RBlank'] = min(x, self.__d['Offset'] - x)
 
     @property
-    def onset(self):
+    def preutterance(self):
         """先行発声を確認する"""
-        return self.__d['Onset']
+        return self.__d['Preutterance']
 
-    @onset.setter
-    def onset(self, x):
+    @preutterance.setter
+    def preutterance(self, x):
         """先行発声を上書きする"""
-        self.__d['Onset'] = x
+        self.__d['Preutterance'] = x
 
     @property
     def overlap(self):

--- a/otoini.py
+++ b/otoini.py
@@ -122,33 +122,33 @@ class OtoIni:
             elif len(aliases) in [2, 3]:
                 name_wav = oto.filename
                 # 1文字目(オーバーラップから先行発声まで)------------
-                tmp = Oto()
+                new = Oto()
                 a = aliases[0]
                 t = oto.offset + oto.overlap  # オーバーラップの位置から
-                tmp.filename = name_wav
-                tmp.alias = a
-                tmp.offset = t
-                tmp.overlap = 0
-                l.append(tmp)
+                new.filename = name_wav
+                new.alias = a
+                new.offset = t
+                new.overlap = 0
+                l.append(new)
                 # 2文字目(先行発声から固定範囲まで)----------------
-                tmp = Oto()
+                new = Oto()
                 a = aliases[1]
                 t = oto.offset + oto.preutterance  # 先行発声の位置から
-                tmp.filename = name_wav
-                tmp.alias = a
-                tmp.offset = t
-                tmp.overlap = 0
-                l.append(tmp)
+                new.filename = name_wav
+                new.alias = a
+                new.offset = t
+                new.overlap = 0
+                l.append(new)
                 if len(aliases) == 3:
                     # 3文字目(固定範囲から右ブランクまで)----------------
-                    tmp = Oto()
+                    new = Oto()
                     a = aliases[2]
                     t = oto.offset + oto.consonant  # 固定範囲の位置から
-                    tmp.filename = name_wav
-                    tmp.alias = a
-                    tmp.offset = t
-                    tmp.overlap = 0
-                    l.append(tmp)
+                    new.filename = name_wav
+                    new.alias = a
+                    new.offset = t
+                    new.overlap = 0
+                    l.append(new)
             else:
                 print('\n[ERROR in otoini.monophonize()]----------------')
                 print('エイリアスのローマ字分割数は 1, 2, 3 以外対応していません。')

--- a/otoini.py
+++ b/otoini.py
@@ -167,7 +167,7 @@ class OtoIni:
             l.append(oto.alias)
             l.append(oto.offset)
             l.append(oto.consonant)
-            l.append(oto.rblank)
+            l.append(oto.cutoff)
             l.append(oto.preutterance)
             l.append(oto.overlap)
             # 数値部分を丸めてから文字列に変換
@@ -183,14 +183,14 @@ class Oto:
 
     def __init__(self):
         keys = ('FileName', 'Alias', 'Offset',
-                'Consonant', 'RBlank', 'Preutterance', 'Overlap')
+                'Consonant', 'Cutoff', 'Preutterance', 'Overlap')
         l = [None] * 7
         self.__d = dict(zip(keys, l))
 
     def from_otoini(self, l):
         """1音分のリストをもらってクラスオブジェクトにする"""
         keys = ('FileName', 'Alias', 'Offset',
-                'Consonant', 'RBlank', 'Preutterance', 'Overlap')
+                'Consonant', 'Cutoff', 'Preutterance', 'Overlap')
         # 数値部分をfloatにする
         l = l[:2] + [float(v) for v in l[2:]]
         self.__d = dict(zip(keys, l))
@@ -250,25 +250,25 @@ class Oto:
         self.__d['Consonant'] = x
 
     @property
-    def rblank(self):
+    def cutoff(self):
         """右ブランクを確認する"""
-        return self.__d['RBlank']
+        return self.__d['Cutoff']
 
-    @rblank.setter
-    def rblank(self, x):
+    @cutoff.setter
+    def cutoff(self, x):
         """右ブランクを上書きする"""
-        self.__d['RBlank'] = x
+        self.__d['Cutoff'] = x
 
     @property
-    def rblank2(self):
+    def cutoff2(self):
         """右ブランクを絶対時刻で取得する"""
-        return max(self.__d['RBlank'], self.__d['Offset'] - self.__d['RBlank'])
+        return max(self.__d['Cutoff'], self.__d['Offset'] - self.__d['Cutoff'])
 
     # OffsetがNullのとき処理できず、バグのもとになるので無効化
-    # @rblank2.setter
-    # def rblank2(self, x):
+    # @cutoff2.setter
+    # def cutoff2(self, x):
     #     """右ブランクを上書きする。負の値に強制する。"""
-    #     self.__d['RBlank'] = min(x, self.__d['Offset'] - x)
+    #     self.__d['Cutoff'] = min(x, self.__d['Offset'] - x)
 
     @property
     def preutterance(self):

--- a/reclist.py
+++ b/reclist.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+UTAUの録音リストを扱うモジュール
+録音リストは休憩する部分で空白行を入れてね
+"""
+
+
+def main():
+    """直接実行されたときの動作"""
+    print('録音リストを扱うためのモジュールです。importして使ってね。')
+
+
+def load(path, mode='r', encoding='shift-jis'):
+    """録音リストを読み取ってオブジェクト生成"""
+    # 録音リストを読み取る
+    with open(path, mode=mode, encoding=encoding) as f:
+        l = [re.split('[=,]', s.strip()) for s in f.readlines()]
+    # # 空白の行を削除
+    # l = [v for v in l if v != '']
+    r = RecList()
+    r.values = l
+    return r
+
+
+class RecList:
+    """録音リスト"""
+
+    def __init__(self):
+        self.__values = []
+
+    @property
+    def values(self):
+        """中身を取得"""
+        return self.__values
+
+    @values.setter
+    def values(self, l):
+        self.__values = l
+
+    def save_as_reaper_region_csv(self, path_csvfile, offset_beats=4):
+        """
+        path_csvfile: 出力パス
+        録音リストからReaperのリージョンCSVをつくる。
+        これを使うと原音の分割が楽にできる。
+        """
+        l = self.values()
+        head = '#,Name,Start,End,Length'
+        for i, v in enumerate():
+            if v != '':
+                name = v
+                start = '{}.1.00'
+                end = '{}.1.00'
+                length = '{}.0.00'
+                line = 'R{},{},'
+
+
+
+
+
+
+
+
+
+
+if __name__ == '__main__':
+    main()

--- a/ust.py
+++ b/ust.py
@@ -117,7 +117,7 @@ class Note:
     """UST内のノート"""
 
     def __init__(self):
-        self.d = {}
+        self.__d = {}
         self.section = None
 
     # ここからデータ入力系-----------------------------------------------------
@@ -129,97 +129,97 @@ class Note:
         # print('Making "Note" instance from UST: {}'.format(section))
         # タグ以外の行の処理
         if section == '[#VERSION]':
-            self.d['Version'] = lines[1]
+            self.__d['Version'] = lines[1]
         elif section == '[#TRACKEND]':
             pass
         else:
             for v in lines[1:]:
                 tmp = v.split('=', 1)
-                self.d[tmp[0]] = tmp[1]
+                self.__d[tmp[0]] = tmp[1]
         return self
     # ここまでデータ入力系-----------------------------------------------------
 
     @property
     def values(self):
         """ノートの中身を見る"""
-        return self.d
+        return self.__d
 
     @values.setter
     def values(self, d):
         """ノートの中身を上書き"""
-        self.d = d
+        self.__d = d
 
     @property
     def section(self):
         """タグを確認"""
-        return self.d['Section']
+        return self.__d['Section']
 
     @section.setter
     def section(self, s):
         """タグを上書き"""
-        self.d['Section'] = s
+        self.__d['Section'] = s
 
     @property
     def length(self):
         """ノート長を確認[samples]"""
-        return self.d['Length']
+        return self.__d['Length']
 
     @length.setter
     def length(self, x):
         """ノート長を上書き[samples]"""
-        self.d['Length'] = x
+        self.__d['Length'] = x
 
     @property
     def lyric(self):
         """歌詞を確認"""
-        return self.d['Lyric']
+        return self.__d['Lyric']
 
     @lyric.setter
     def lyric(self, x):
         """歌詞を上書き"""
-        self.d['Lyric'] = x
+        self.__d['Lyric'] = x
 
     @property
     def notenum(self):
         """音階番号を確認"""
-        return self.d['NoteNum']
+        return self.__d['NoteNum']
 
     @notenum.setter
     def notenum(self, x):
         """音階番号を上書き"""
-        self.d['NoteNum'] = x
+        self.__d['NoteNum'] = x
 
     @property
     def tempo(self):
         """BPMを確認"""
-        return self.d['Tempo']
+        return self.__d['Tempo']
 
     @tempo.setter
     def tempo(self, x):
         """BPMを上書き"""
-        self.d['Tempo'] = x
+        self.__d['Tempo'] = x
 
     # ここからデータ操作系-----------------------------------------------------
     # NOTE: msで長さ操作する二つ、テンポ取得を自動にしていい感じにしたい。
     def get_by_key(self, key):
         """ノートの特定の情報を上書きまたは登録"""
         try:
-            return self.d[key]
+            return self.__d[key]
         except KeyError as e:
             print('KeyError Exception in get_by_key in ust.py : {}'.format(e))
             return None
 
     def set_by_key(self, key, x):
         """ノートの特定の情報を上書きまたは登録"""
-        self.d[key] = x
+        self.__d[key] = x
 
     def get_length_ms(self, tempo):
         """ノート長を確認[ms]"""
-        return 125 * float(self.d['Length']) / float(tempo)
+        return 125 * float(self.__d['Length']) / float(tempo)
 
     def set_length_ms(self, x, tempo):
         """ノート長を上書き[ms]"""
-        self.d['Length'] = x * tempo // 125
+        self.__d['Length'] = x * tempo // 125
     # ここまでデータ操作系-----------------------------------------------------
 
     # ここからノート操作系-----------------------------------------------------
@@ -248,7 +248,7 @@ class Note:
         new_note['Lyric'] = self.lyric
         new_note['Length'] = self.length
         new_note['NoteNum'] = self.notenum
-        self.d = new_note
+        self.__d = new_note
     # ここまでノート操作系-----------------------------------------------------
 
     # ここからデータ出力系-----------------------------------------------------
@@ -256,7 +256,7 @@ class Note:
     # -------------------------------------------------------------------------
     # def as_lines(self):
     #     """出力用のリストを返す"""
-    #     d = self.d
+    #     d = self.__d
     #     lines = []
     #     lines.append(d.pop('Section'))
     #     for k, v in d.items():


### PR DESCRIPTION
otoiniの変数と関数名を他者のUTAU向けライブラリに合わせた。
- filename -> filename（wavファイル名）
- alies **(typo)** -> alias（エイリアス）
- lblank -> offset（左ブランク）
- overlap ->overlap（オーバーラップ）
- onset -> preutterance（先行発声）
- fixed -> consonant（子音部固定範囲）