### PR TITLE
Remove usages of outdated function "set_by_key"

### DIFF
--- a/utaupy/convert.py
+++ b/utaupy/convert.py
@@ -34,7 +34,7 @@ def svp2ust(svp, debug=False):
     # ust.append(utaunote)
 
     # プロジェクト設定のノートを追加
-    ust.setting.set_by_key('Tempo', svp['time']['tempo'][0]['bpm'])
+    ust.setting['Tempo'] = svp['time']['tempo'][0]['bpm']
 
     previous_onset = 0
     for svnote in svnotes:

--- a/utaupy/utau.py
+++ b/utaupy/utau.py
@@ -188,11 +188,11 @@ def autoadjust_parameters(voicebank, utaupy_ust_ust):
         if halflen < oto.preutterance - oto.overlap:
             at_preuttr = halflen * oto.preutterance / (oto.preutterance - oto.overlap)
             at_overlap = halflen * oto.overlap / (oto.preutterance - oto.overlap)
-            note.set_by_key('StartPoint', oto.preutterance - at_preuttr)
-            note.set_by_key('PreUtterance', at_preuttr)
-            note.set_by_key('VoiceOverlap', at_overlap)
+            note['StartPoint'] = oto.preutterance - at_preuttr
+            note['PreUtterance'] = at_preuttr
+            note['VoiceOverlap'] = at_overlap
             print('adjust')
         else:
-            note.set_by_key('StartPoint', 0)
-            note.set_by_key('PreUtterance', oto.preutterance)
-            note.set_by_key('VoiceOverlap', oto.overlap)
+            note['StartPoint'] = 0
+            note['PreUtterance'] = oto.preutterance
+            note['VoiceOverlap'] = oto.overlap


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "oto2lab.py", line 369, in <module>
    main_cli()
  File "oto2lab.py", line 308, in main_cli
    svpfile_to_inifile(path, path_tablefile)
  File "oto2lab.py", line 236, in svpfile_to_inifile
    ust = up.convert.svp2ust(svp, debug=DEBUG_MODE)
  File "xxxxxxxxxxxxxxxx/lib/python3.7/site-packages/utaupy/convert.py", line 37, in svp2ust
    ust.setting.set_by_key('Tempo', svp['time']['tempo'][0]['bpm'])
```
が出ましたので修正をしました。

oto2labで、utaupyの最新バージョンを取り込んだ後に発生するようになりました。

一応、同じような修正をoto2labでも該当する箇所があるのでしましたが、pythonのdependency versioningには詳しくないため、ご判断をお願いします（該当コードが使われているかどうかも確認していません…）：https://github.com/sdercolin/oto2lab/commit/048257c55520984ee0fc7c596115126df36efb77
