### PR TITLE
Allow tempo to decimal point

### DIFF
--- a/utaupy/hts.py
+++ b/utaupy/hts.py
@@ -1215,7 +1215,7 @@ class Note(UserList):
         """
         if 'xx' in (self.tempo, self.length):
             return 'xx'
-        return float(25000000 * int(self.length) / int(self.tempo))
+        return float(25000000 * int(self.length) / float(self.tempo))
 
     @property
     def position(self):

--- a/utaupy/hts.py
+++ b/utaupy/hts.py
@@ -1215,7 +1215,7 @@ class Note(UserList):
         """
         if 'xx' in (self.tempo, self.length):
             return 'xx'
-        return float(25000000 * int(self.length) / float(self.tempo))
+        return Decimal(25000000 * int(self.length) / Decimal(self.tempo))
 
     @property
     def position(self):

--- a/utaupy/utils/_ust2hts.py
+++ b/utaupy/utils/_ust2hts.py
@@ -48,7 +48,7 @@ def ustnote2htsnote(
     #     )
     # ------------------------------------------
     # e5
-    hts_note.tempo = round(ust_note.tempo)
+    hts_note.tempo = ust_note.tempo
     # e8
     hts_note.length = round(ust_note.length / 20)
 

--- a/utaupy/utils/_ust2hts.py
+++ b/utaupy/utils/_ust2hts.py
@@ -23,7 +23,7 @@ d2, d3, e2, e3, f2, f3 はスケール判定が必要なため、実行時にキ
 d3, e3, f3 には 'xx' を代入する。歌うときに休符の学習データ引っ張ってきそうな気はする。
 """
 import utaupy as up
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 
 
 def ustnote2htsnote(

--- a/utaupy/utils/_ust2hts.py
+++ b/utaupy/utils/_ust2hts.py
@@ -23,6 +23,7 @@ d2, d3, e2, e3, f2, f3 はスケール判定が必要なため、実行時にキ
 d3, e3, f3 には 'xx' を代入する。歌うときに休符の学習データ引っ張ってきそうな気はする。
 """
 import utaupy as up
+from decimal import *
 
 
 def ustnote2htsnote(
@@ -48,7 +49,7 @@ def ustnote2htsnote(
     #     )
     # ------------------------------------------
     # e5
-    hts_note.tempo = ust_note.tempo
+    hts_note.tempo = Decimal(ust_note.tempo) 
     # e8
     hts_note.length = round(ust_note.length / 20)
 

--- a/utaupy/utils/_ust2hts.py
+++ b/utaupy/utils/_ust2hts.py
@@ -23,7 +23,7 @@ d2, d3, e2, e3, f2, f3 はスケール判定が必要なため、実行時にキ
 d3, e3, f3 には 'xx' を代入する。歌うときに休符の学習データ引っ張ってきそうな気はする。
 """
 import utaupy as up
-from decimal import *
+from decimal import ROUND_HALF_UP, Decimal
 
 
 def ustnote2htsnote(
@@ -49,7 +49,7 @@ def ustnote2htsnote(
     #     )
     # ------------------------------------------
     # e5
-    hts_note.tempo = Decimal(ust_note.tempo) 
+    hts_note.tempo = Decimal(ust_note.tempo)
     # e8
     hts_note.length = round(ust_note.length / 20)
 


### PR DESCRIPTION
OpenUtauプロジェクトのIssueで、テンポが小数点まで入力されている場合、ラベル作成時にタイミングがずれる問題（https://github.com/stakira/OpenUtau/issues/431 ）が出ていたので、丸め込まないように変更した。

Issue in the OpenUtau project (https://github.com/stakira/OpenUtau/issues/431 ) where the timing was off when creating labels if tempo was entered to the decimal point, so it was changed to not rounding.
